### PR TITLE
Enhancing TRM data tables

### DIFF
--- a/app/app.R
+++ b/app/app.R
@@ -1,82 +1,268 @@
 
-library(shiny); library(shinythemes); library(shinydashboard);
+# Call required packages
+library(shiny)
+library(shinythemes)
+library(shinydashboard)
+library(DT)
+library(dplyr)
 
-trmData <- read.csv("trm-data.csv", header = TRUE)
-
-ui <- dashboardPage(skin = "black",
-                    dashboardHeader(title = "Handy Toolset"),
-                    dashboardSidebar(
-                        sidebarMenu(
-                            menuItem("TRM Calculator", tabName = "trm", icon = icon("calculator"), 
-                                     badgeLabel = "calculate", badgeColor = "red"),
-                            menuItem("Other Handy Tool", tabName = "futuretool", icon = icon("vial"),
-                                     badgeLabel = "future", badgeColor = "orange")
-                        )
-                    ),
-                    dashboardBody(
-                        tabItems(
-                            tabItem(tabName = "trm",
-                                    fluidRow(
-                                             box(
-                                              selectInput("performance", "Performance Status", choices = c("0", "1", "2", "3", "4")),
-                                               numericInput("platelets","Platelet Count",min = 0, value=NULL),
-                                               numericInput("albumin","Albumin",min = 0, value=NULL),
-                                               numericInput("age","Age",min = 0,max = 125, value=NULL),
-                                               checkboxInput("secondaryAML", "Secondary AML?", value = FALSE)
-                                             ),
-                                             box(
-                                               numericInput("wbc","WBC",min = 0, value=NULL),
-                                               numericInput("blast","% Blast in Peripheral Blood",min = 0,max = 100, value=NULL),
-                                               numericInput("creatinine","Creatinine",min = 0, value=NULL),
-                                               actionButton(inputId = "calculateNow", 
-                                                            label = "Calculate"),
-                                               actionButton(inputId = "reset", 
-                                                            label = "Reset Button doesn't work yet"),
-                                               textOutput(outputId = "trmScore")
-                                             )
-                                    ),
-                                    fluidRow(
-                                      column(12, tableOutput(outputId = "trmTable"))
-                                    ),
-                                    fluidRow(
-                                      column(12, 
-        
-                                    box(width = 12, "Publication URL: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3221524/
-                                        
-                                        Prediction of Treatment-Related Mortality after Induction Therapy for Newly Diagnosed Acute Myeloid Leukemia
-
-It is well known that the risk treatment-related mortality (TRM) varies considerably between individual patients with acute myeloid leukemia (AML). Numerous factors have been identified that are individually associated with this risk, including age and covariates that may serve as surrogates for the biological (rather than chronological) age, such as performance status, organ function parameters (e.g. bilirubin, fibrinogen, albumin, creatinine), degree of cytopenias, and disease characteristics.
-
-Using data from 3,365 adults of all ages administered intensive chemotherapy for newly diagnosed AML on SWOG trials or at M.D. Anderson Cancer Center between 1986 and 2009, we defined TRM as death within 28 days from initiation of chemotherapy based on the observation that the risk of death declined once 4 weeks had elapsed from treatment start.1
-
-We then used the area under the receiver operator characteristic curve (AUC) to quantify the relative effects of individual covariates on TRM in a subset of 2,238 patients treated between 1986 and 2009 at M.D. Anderson Cancer Center. We found that multicomponent models were significantly more accurate in predicting TRM than individual covariates alone. A maximal model comprised of 17 covariates yielded an AUC of 0.83. Omission of covariates of lesser importance led to a “simplified” model that included performance status, age, platelet count, serum albumin, type of AML (secondary vs. primary), white blood cell count, percentage of blasts in the peripheral blood, and serum creatinine, yielding an AUC of 0.82.")
-                        ))),
-                            tabItem(tabName = "futuretool",
-                                    box(align = "center",
-                                             h3("What else would be handy to have right next to this calculator? Could we put it here?")),
-                                    )
-                    )
+# Read in TRM table for simplified model without age
+trmData <- read.csv(
+  "trm-data-ageAgnostic.csv", 
+  header = TRUE,
+  check.names = FALSE
 )
+
+# Read in TRM table for simplified model with age for 60+
+trmDataSixtyPlus <- read.csv(
+  "trm-data-sixtyplus.csv", 
+  header = TRUE,
+  check.names = FALSE
+)
+
+# Read in TRM table for simplified model with age for 60 and under
+trmDataUnderSixty <- read.csv(
+  "trm-data-undersixty.csv", 
+  header = TRUE,
+  check.names = FALSE
+)
+
+# Define the possible trm Intervals
+trmIntervals_list <- trmData$`TRM Score Interval`
+
+# Set up User Interface
+ui <- dashboardPage(
+  skin = "black",
+  
+  dashboardHeader(
+    title = "Handy Toolset"
+  ),
+  
+  dashboardSidebar(
+    sidebarMenu(
+      menuItem(
+        "TRM Calculator", 
+        tabName = "trm", 
+        icon = icon("calculator"), 
+        badgeLabel = "calculate", 
+        badgeColor = "red"
+      ),
+      menuItem(
+        "Other Handy Tool", 
+        tabName = "futuretool", 
+        icon = icon("vial"),
+        badgeLabel = "future", 
+        badgeColor = "orange"
+      )
+    )
+  ),
+  
+  dashboardBody(
+    tabItems(
+      tabItem(
+        tabName = "trm",
+        fluidRow(
+          box(
+            selectInput("performance", "Performance Status", choices = c("0", "1", "2", "3", "4")),
+            numericInput("platelets", "Platelet Count", min = 0, value = NULL),
+            numericInput("albumin", "Albumin", min = 0, value = NULL),
+            numericInput("age", "Age", min = 0, max = 125, value = NULL),
+            checkboxInput("secondaryAML", "Secondary AML?", value = FALSE)
+          ),
+          box(
+            numericInput("wbc", "WBC", min = 0, value = NULL),
+            numericInput("blast", "% Blast in Peripheral Blood", min = 0, max = 100, value = NULL),
+            numericInput("creatinine", "Creatinine", min = 0, value = NULL),
+            actionButton(inputId = "calculateNow", label = "Calculate"),
+            textOutput(outputId = "trmScore"),
+            actionButton(inputId = "reset", label = "Reset")
+          )
+        ),
+        
+        fluidRow(
+          column(12, DTOutput(outputId = "trmTable")),
+          column(12, DTOutput(outputId = "trmTableSixtyPlus")),
+          column(12, DTOutput(outputId = "trmTableUnderSixty"))
+        ),
+        
+        fluidRow(
+          column(12, 
+                 box(
+                   width = 12, 
+                   "Publication URL: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3221524/. Prediction of Treatment-Related Mortality after Induction Therapy for Newly Diagnosed Acute Myeloid Leukemia - It is well known that the risk treatment-related mortality (TRM) varies considerably between individual patients with acute myeloid leukemia (AML). Numerous factors have been identified that are individually associated with this risk, including age and covariates that may serve as surrogates for the biological (rather than chronological) age, such as performance status, organ function parameters (e.g. bilirubin, fibrinogen, albumin, creatinine), degree of cytopenias, and disease characteristics. Using data from 3,365 adults of all ages administered intensive chemotherapy for newly diagnosed AML on SWOG trials or at M.D. Anderson Cancer Center between 1986 and 2009, we defined TRM as death within 28 days from initiation of chemotherapy based on the observation that the risk of death declined once 4 weeks had elapsed from treatment start. We then used the area under the receiver operator characteristic curve (AUC) to quantify the relative effects of individual covariates on TRM in a subset of 2,238 patients treated between 1986 and 2009 at M.D. Anderson Cancer Center. We found that multicomponent models were significantly more accurate in predicting TRM than individual covariates alone. A maximal model comprised of 17 covariates yielded an AUC of 0.83. Omission of covariates of lesser importance led to a “simplified” model that included performance status, age, platelet count, serum albumin, type of AML (secondary vs. primary), white blood cell count, percentage of blasts in the peripheral blood, and serum creatinine, yielding an AUC of 0.82."
+                 )
+          )
+        )
+      ),
+      
+      tabItem(
+        tabName = "futuretool",
+        box(
+          align = "center",
+          h3("What else would be handy to have right next to this calculator? Could we put it here?")
+        ),
+      )
+    )
+  )
 )
 
 # Define server logic required 
 server <- function(input, output, session) {
-
-  calculation <- eventReactive(input$calculateNow, {
-        #x = −4.08 + 0.89 × PS + 0.03 × age − 0.008 × platelets − 0.48 × albumin + 0.47 × (have secondary AML) + 0.007 × WBC − 0.007 × (peripheral blood blast percentage) + 0.34 × creatinine.
-    round(100/(1+ exp(-(-4.08 + 0.89*as.numeric(input$performance) + 0.03*input$age - 0.008*input$platelets - 0.48*input$albumin + 0.47*ifelse(input$secondaryAML==T,1,0)  + 0.007*input$wbc - 0.007*input$blast + 0.34*input$creatinine))), digits = 4)
-       }, ignoreInit = TRUE, ignoreNULL = TRUE)
-  output$trmTable <- renderTable(trmData)
-  output$trmScore <- renderText({ paste0("The TRM Score is: ", calculation() )})
+  vals <- reactiveValues(
+    row_priority = trmIntervals_list,
+    row_color = rep('white', 7)
+  )
+  
+  calculation <- eventReactive(
+    input$calculateNow, 
+    {
+      PS = as.numeric(input$performance)
+      age = input$age
+      platelets = input$platelets
+      albumin = input$albumin
+      hasSecondaryAML = ifelse(input$secondaryAML==T,1,0)
+      WBC = input$wbc # white blood count
+      PBBP = input$blast # peripheral blood blast percentage
+      creatinine = input$creatinine
+      
+      x = -4.08 + 0.89*PS + 0.03*age - 0.008*platelets - 0.48*albumin +
+        0.47*hasSecondaryAML  + 0.007*WBC - 0.007*PBBP + 0.34*creatinine
+      
+      round(
+        100/(1 + exp(-x)),
+        digits = 4
+      )
+    },
+    
+    ignoreInit = TRUE,
+    ignoreNULL = TRUE
+  )
+  
+  
+  output$trmScore <- renderText({
+    paste0("The TRM Score is: ", calculation())
+  })
+  
+  
+  # Based on calculated TRM score, figure out which row to highlight in table
+  highlightedRow <- eventReactive(input$calculateNow, {
+    chosenTrmInterval = "0 - 1.9"
+    
+    # Iterate over options in the TRM intervals and match the score
+    for(elem in trmIntervals_list){
+      minValue = as.numeric(strsplit(elem, " - ")[[1]][1])
+      maxValue = as.numeric(strsplit(elem, " - ")[[1]][2])
+      # If we find the right row, we can break out of our loop
+      if(calculation() >= minValue && calculation() <= maxValue){
+        chosenTrmInterval = elem
+        break
+      }
+    }
+    
+    # Match the identified row with the right highlight color
+    vals$row_priority <- c(
+      chosenTrmInterval, 
+      vals$row_priority[vals$row_priority != chosenTrmInterval]
+    )
+    vals$row_color <- c(
+      'lightgreen', #TODO: maybe change colors to Hutch themes?
+      'white', 'white', 'white', 'white', 'white', 'white'
+    )
+    
+    vals
+  })
+  
+  # Show the data table for the simplified model
+  output$trmTable <- renderDT(
+    datatable(
+      trmData,
+      caption = "Simplified Model without Age"
+    ) %>%
+      formatStyle(
+        "TRM Score Interval",
+        target = "row",
+        backgroundColor = styleEqual(
+          highlightedRow()$row_priority,
+          highlightedRow()$row_color,
+          default = 'white'
+        )
+      )
+  )
+  
+  # Show the data table for the simplified model + relevant age
+  observeEvent(input$calculateNow, {
+    # If age > 60, show only the older age table
+    if(input$age > 60){
+      output$trmTableSixtyPlus <- renderDT(
+        datatable(
+          trmDataSixtyPlus,
+          caption = "Simplified Model with Age (Over 60)"
+        ) %>%
+          formatStyle(
+            "TRM Score Interval",
+            target = "row",
+            backgroundColor = styleEqual(
+              highlightedRow()$row_priority,
+              highlightedRow()$row_color,
+              default = 'white'
+            )
+          )
+      )
+      
+      output$trmTableUnderSixty <- renderDT({})
+    }
+    
+    # If age <= 60, show only the younger age table
+    if(input$age <= 60){
+      output$trmTableUnderSixty <- renderDT(
+        datatable(
+          trmDataUnderSixty,
+          caption = "Simplifed Model with Age (60 and under)"
+        ) %>%
+          formatStyle(
+            "TRM Score Interval",
+            target = "row",
+            backgroundColor = styleEqual(
+              highlightedRow()$row_priority,
+              highlightedRow()$row_color,
+              default = 'white'
+            )
+          )
+      )
+      
+      output$trmTableSixtyPlus <- renderDT({})
+    }
+  })
+  
+  # Hitting the reset button will clear all values
+  observeEvent(input$reset, {
+    updateSelectInput(session,"performance", selected = 0)
+    updateNumericInput(session, "platelets", value = NA)
+    updateNumericInput(session, "albumin", value = NA)
+    updateNumericInput(session, "age", value = NA)
+    updateCheckboxInput(session, "secondaryAML", value = FALSE)
+    updateNumericInput(session, "wbc", value = NA)
+    updateNumericInput(session, "blast", value = NA)
+    updateNumericInput(session, "creatinine", value = NA)
+    output$trmScore <- renderText({""})
+    output$trmTableSixtyPlus <- renderDT({})
+    output$trmTableUnderSixty <- renderDT({})
+    output$trmTable <- renderDT({})
+  })
 }
+
 
 # Run the application 
 options <- list()
+
 if (!interactive()) {
   options$port = 3838
   options$launch.browser = FALSE
   options$host = "0.0.0.0"
-
 }
-shinyApp(ui, server, options=options)
 
+shinyApp(
+  ui, 
+  server, 
+  options = options
+)

--- a/app/trm-data-ageAgnostic.csv
+++ b/app/trm-data-ageAgnostic.csv
@@ -1,0 +1,8 @@
+"TRM Score Interval","Percent of Patients below TRM Score Interval (%)","TRM Probability if below TRM Score Interval (%)","Percent of Patients within TRM Score Interval (%)","TRM Probability if within TRM Score Interval (%)","Percent of Patients above TRM Score Interval (%)","TRM Probability if above TRM Score Interval (%)"
+"0 - 1.9","0","Not Applicable","20","1","80","12"
+"1.91 - 3.9","20","1","20","2","60","16"
+"3.91 - 6.9","40","1","20","7","40","20"
+"6.91 - 9.2","60","3","10","7","30","24"
+"9.21 - 13.1","70","4","10","12","20","31"
+"13.11 - 22.8","80","5","10","20","10","41"
+"22.81 - 100","90","6","10","41","0","Not Applicable"

--- a/app/trm-data-sixtyplus.csv
+++ b/app/trm-data-sixtyplus.csv
@@ -1,0 +1,8 @@
+"TRM Score Interval","Percent of Patients above TRM Score Interval (%)","TRM Probability if above TRM Score Interval (%)"
+"0 - 1.9","67","10"
+"1.91 - 3.9","39","15"
+"3.91 - 6.9","21","18"
+"6.91 - 9.2","14","26"
+"9.21 - 13.1","9","35"
+"13.11 - 22.8","5","53"
+"22.81 - 100","Not Applicable","Not Applicable"

--- a/app/trm-data-undersixty.csv
+++ b/app/trm-data-undersixty.csv
@@ -1,0 +1,8 @@
+"TRM Score Interval","Percent of Patients above TRM Score Interval (%)","TRM Probability if above TRM Score Interval (%)"
+"0 - 1.9","67","10"
+"1.91 - 3.9","39","15"
+"3.91 - 6.9","21","18"
+"6.91 - 9.2","14","26"
+"9.21 - 13.1","9","35"
+"13.11 - 22.8","5","53"
+"22.81 - 100","Not Applicable","Not Applicable"


### PR DESCRIPTION
Separated the original TRM data table into its components based on the relevant models described from Walter et al. Now we have separate tables for the original simplified model and the simplified model + age (relevant to the input calculated age). Also introduced auto high-lighting of the relevant row in each table based upon the calculated TRM score.