### PR TITLE
Change ADD to include app/www/ folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN apt-get update
 RUN apt-get install -y pandoc
 RUN R -e "install.packages(c('shiny', 'shinythemes', 'shinydashboard', 'shinyvalidate', 'dplyr', 'gt', 'gtExtras'), repos='https://cran.rstudio.com/')"
 
-ADD app/. /home/shiny/
+ADD app/ /home/shiny/
 RUN R -f /home/shiny/check.R --args shiny shinythemes shinydashboard shinyvalidate dplyr gt gtExtras
 RUN chown -R shiny:shiny /home/shiny 
 WORKDIR /home/shiny


### PR DESCRIPTION
Updated Dockerfile from `ADD app/.` to `ADD app/` - I think this should successfully include the `www` folder in addition to the files in the `app` directory, allowing for the logo to show up on the webpage.